### PR TITLE
Nvidia driver 396 dependencies error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 
 MAINTAINER Simone Roberto Nunzi "simone.roberto.nunzi@gmail.com"
 

--- a/build.sh
+++ b/build.sh
@@ -60,6 +60,8 @@ if [ -n "$COMPATIBILITY" ]; then
 		installpackages+="pciutils "
 		installpackages+="lsb-release "
 		# Nvidia
+		installpackages+="xserver-xorg-core "
+		installpackages+="xserver-xorg-video-nvidia-396 "
 		installpackages+="nvidia-driver-396 "
 		installpackages+="nvidia-prime "
 


### PR DESCRIPTION
I found a solution to deal with this [issue](https://github.com/stockmind/dell-xps-9560-ubuntu-respin/issue/52); using docker.
Updating the packages installed when using the option `-c bionicbeaver` (respin for Ubuntu 18.04) works. To take into account changes made to the script `build.sh`, a simple solution is to rebuild the respin docker image (dell-xps-9560-ubuntu-respin). This is problematic because of changes made to the ubuntu repositories (even after removing all local images). A simple solution that works fine is to build the respin image from ubuntu 18.04 instead of ubuntu 17.10.
